### PR TITLE
Fix issue with foam filling screen at certain angles in godot 4.2.1

### DIFF
--- a/realistic_water_shader/art/water/Water.gdshader
+++ b/realistic_water_shader/art/water/Water.gdshader
@@ -160,7 +160,7 @@ void fragment()
 	if (depth + VERTEX.z < vertex_height-0.1)
 	{
 		float foam_noise = clamp(pow(texture(foam_sampler, (uv*4.0) - uv_offset).r, 10.0)*40.0, 0.0, 0.2);
-		float foam_mix = clamp(pow((1.0-(depth + VERTEX.z) + foam_noise), 3.0) * foam_noise * 0.4, 0.0, 1.0);
+		float foam_mix = clamp(pow((1.0-(depth + VERTEX.z) + foam_noise), 3.0) * foam_noise, 0.0, 1.0);
 		color = mix(color, vec3(1.0), foam_mix);
 	}
 	

--- a/realistic_water_shader/art/water/Water.gdshader
+++ b/realistic_water_shader/art/water/Water.gdshader
@@ -160,7 +160,7 @@ void fragment()
 	if (depth + VERTEX.z < vertex_height-0.1)
 	{
 		float foam_noise = clamp(pow(texture(foam_sampler, (uv*4.0) - uv_offset).r, 10.0)*40.0, 0.0, 0.2);
-		float foam_mix = clamp(pow((1.0-(depth + VERTEX.z) + foam_noise), 8.0) * foam_noise * 0.4, 0.0, 1.0);
+		float foam_mix = clamp(pow((1.0-(depth + VERTEX.z) + foam_noise), 3.0) * foam_noise * 0.4, 0.0, 1.0);
 		color = mix(color, vec3(1.0), foam_mix);
 	}
 	


### PR DESCRIPTION
Just tweaked some attributes to avoid the foam issue at certain angles.

Before:
![image](https://github.com/godot-extended-libraries/godot-realistic-water/assets/51462138/b45340f6-25aa-4d0c-ac89-9bd8607a3460)

After:
![image](https://github.com/godot-extended-libraries/godot-realistic-water/assets/51462138/225f2f60-ecea-4ba2-ad26-6e5b9ac28adb)
